### PR TITLE
Переделана процедура загрузки OAuth ресурсов

### DIFF
--- a/CloudMusicPlayer/Main.storyboard
+++ b/CloudMusicPlayer/Main.storyboard
@@ -136,7 +136,7 @@
                                 </constraints>
                                 <state key="normal" title="Log in"/>
                                 <connections>
-                                    <action selector="logIn:" destination="ZIg-ge-mcq" eventType="touchUpInside" id="8qP-xV-7X7"/>
+                                    <action selector="logIn:" destination="ZIg-ge-mcq" eventType="touchUpInside" id="6uQ-Kc-FL3"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tdn-Sh-xKE">
@@ -147,7 +147,7 @@
                                 </constraints>
                                 <state key="normal" title="Log out"/>
                                 <connections>
-                                    <action selector="logOut:" destination="ZIg-ge-mcq" eventType="touchUpInside" id="DLN-df-Ole"/>
+                                    <action selector="logOut:" destination="ZIg-ge-mcq" eventType="touchUpInside" id="8Ta-8D-Jpy"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -191,8 +191,8 @@
                     </view>
                     <tabBarItem key="tabBarItem" title="Settings" id="hae-Id-lbw"/>
                     <connections>
-                        <outlet property="logInButton" destination="soC-Ii-Uy8" id="NOH-jO-SGl"/>
-                        <outlet property="logOutButton" destination="tdn-Sh-xKE" id="juJ-k1-oOy"/>
+                        <outlet property="logInButton" destination="soC-Ii-Uy8" id="gtB-gf-enc"/>
+                        <outlet property="logOutButton" destination="tdn-Sh-xKE" id="NAQ-G8-9xw"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4Mp-qw-vTn" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/CloudMusicPlayer/SettingsController.swift
+++ b/CloudMusicPlayer/SettingsController.swift
@@ -15,7 +15,7 @@ class SettingsController: UIViewController {
 	
 	@IBOutlet weak var logOutButton: UIButton!
 	
-	private unowned let yandexOauth: YandexOAuthResource = OAuthResourceBase.Yandex as! YandexOAuthResource
+	private let yandexOauth: YandexOAuthResource = OAuthResourceBase.Yandex as! YandexOAuthResource
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()

--- a/CloudMusicPlayer/Yandex.swift
+++ b/CloudMusicPlayer/Yandex.swift
@@ -9,8 +9,10 @@
 import Foundation
 
 public class YandexOAuthResource : OAuthResourceBase {
-	init() {
+	private init() {
 		super.init(id: .Yandex, authUrl: "https://oauth.yandex.ru/authorize?response_type=token", clientId: "6556b9ed6fb146ea824d2e1f0d98f09b", tokenId: nil)
+		OAuthResourceBase.resources[CloudResourceType.Yandex.rawValue] = self
+		self.saveResource()
 	}
 	
 	@objc required public init?(coder aDecoder: NSCoder) {
@@ -27,7 +29,9 @@ public class YandexOAuthResource : OAuthResourceBase {
 
 extension OAuthResourceBase {
 	public static var Yandex: OAuthResource {
-		return getResourceById(.Yandex) ?? YandexOAuthResource()
+		return loadResourceById(.Yandex) ?? {
+			return YandexOAuthResource()
+		}()
 	}
 	
 	public static func parseYandexCallbackUrl(url: String) -> OAuthResource? {


### PR DESCRIPTION
Теперь loadResourceById только возвращает ресурс из локального
хранилища (словарь resources), если его там нет, то загружает его из
NSUserDefaults, если там тоже нет, то возвращается nil.
Метод getResourceById теперь сначала вызывает loadResourceById, если
вернулся nil, то он возвращает тот ресурс, который у него просят (если
требуют что-то непонятное, то nil). На данный момент он вызывает только
extension для яндекса.
Расширяющее свойство Yandex пытается так же загрузить ресурс через
loadResourceById, если не получается, то возвращает новый ресурс.
